### PR TITLE
Fixes #3 Install deps from requirements.txt even in pip installation

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,9 @@ of patent rights can be found in the PATENTS file in the same directory.
 """
 from setuptools import setup
 
+with open('requirements.txt') as f:
+    requirements = f.read().splitlines()
+
 setup(
     name='fbpca',
     version='1.0',
@@ -20,6 +23,8 @@ setup(
     py_modules=['fbpca'],
     license='BSD License',
     platforms='Any',
+    include_package_data=True,
+    install_requires=requirements,
     long_description=open('README.rst').read(),
     classifiers=[
         'Intended Audience :: Science/Research',


### PR DESCRIPTION
Fixes #3 Install deps from requirements.txt even in pip installation

@ajtulloch Please review thanks